### PR TITLE
[ChartJS] [Dev] Redact Django key

### DIFF
--- a/ChartJS/examples/chart_maker/README.md
+++ b/ChartJS/examples/chart_maker/README.md
@@ -1,0 +1,10 @@
+<div dir="ltr">
+
+# Running Chart Maker
+
+This sample reads `SECRET_KEY` from the `DJANGO_SECRET_KEY` environment variable. Do not commit the real value in project files. If the variable is missing, Django stops with a settings error.
+
+Reference:
+[Django SECRET_KEY setting](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-SECRET_KEY)
+
+</div>

--- a/ChartJS/examples/chart_maker/chartmaker/settings.py
+++ b/ChartJS/examples/chart_maker/chartmaker/settings.py
@@ -10,7 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import os
 from pathlib import Path
+
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,7 +23,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-xh=-w+$90up_m*qjk_g@ab^$%%8y%f3nce!70=m=kh)mn^pjv0'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    raise ImproperlyConfigured('DJANGO_SECRET_KEY environment variable is required.')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## What changed

- Read Django `SECRET_KEY` from `DJANGO_SECRET_KEY`.
- Added a short README note for the sample.

## Why

The old key was already revoked, but HEAD should not keep credential-shaped values.